### PR TITLE
Adds enable setting

### DIFF
--- a/turnstile/fields.py
+++ b/turnstile/fields.py
@@ -7,7 +7,7 @@ from urllib.request import build_opener, Request, ProxyHandler
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
-from turnstile.settings import DEFAULT_CONFIG, PROXIES, SECRET, TIMEOUT, VERIFY_URL
+from turnstile.settings import DEFAULT_CONFIG, ENABLE, PROXIES, SECRET, TIMEOUT, VERIFY_URL
 from turnstile.widgets import TurnstileWidget
 
 
@@ -46,6 +46,8 @@ class TurnstileField(forms.Field):
         return attrs
 
     def validate(self, value):
+        if not ENABLE:
+            return
         super().validate(value)
         opener = build_opener(ProxyHandler(PROXIES))
         post_data = urlencode({

--- a/turnstile/settings.py
+++ b/turnstile/settings.py
@@ -7,3 +7,4 @@ SECRET = getattr(settings, 'TURNSTILE_SECRET', '1x000000000000000000000000000000
 TIMEOUT = getattr(settings, 'TURNSTILE_TIMEOUT', 5)
 DEFAULT_CONFIG = getattr(settings, 'TURNSTILE_DEFAULT_CONFIG', {})
 PROXIES = getattr(settings, 'TURNSTILE_PROXIES', {})
+ENABLE = getattr(settings, 'TURNSTILE_ENABLE', True)

--- a/turnstile/widgets.py
+++ b/turnstile/widgets.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlencode
 from django import forms
-from turnstile.settings import JS_API_URL, SITEKEY
+from turnstile.settings import JS_API_URL, SITEKEY, ENABLE
 
 
 class TurnstileWidget(forms.Widget):
@@ -9,6 +9,10 @@ class TurnstileWidget(forms.Widget):
     def __init__(self, *args, **kwargs):
         self.extra_url = {}
         super().__init__(*args, **kwargs)
+
+    @property
+    def is_hidden(self):
+        return not ENABLE
 
     def value_from_datadict(self, data, files, name):
         return data.get('cf-turnstile-response')
@@ -24,3 +28,8 @@ class TurnstileWidget(forms.Widget):
         if self.extra_url:
             context['api_url'] += '?' + urlencode(self.extra_url)
         return context
+
+    def render(self, name, value, attrs=None, renderer=None):
+        if not ENABLE:
+            return ""
+        return super().render(name, value, attrs, renderer)


### PR DESCRIPTION
Adds an `TURNSTILE_ENABLE` setting.  So adding:
`TURNSTILE_ENABLE = not DEBUG` to settings will enable rapid development without the extra calls and time made to the cloudflare servers.  