### PR TITLE
Add support for remoteip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,3 +106,28 @@ You will need to disable the Turnstile field in your unit tests, since your test
         def test_something(self, mock: MagicMock) -> None:
             response = self.client.post("/contact/", self.test_msg)
             self.assertEqual(response.status_code, HTTP_302_FOUND)
+
+Remote IP
+------------------
+In order to improve bot detection, Turnstile accepts an optional parameter remoteip with the the visitor's IP address.
+During server-side validation, it's sent to Cloudflare and it's used as bonus/malus during bot index calculation.
+Before using it, make sure to verify whether your country requires a notice or disclaimer, since you may be collecting user information.
+
+remote_ip should be passed from view to form to Turnstile field, you can find an example below.
+Note that this is an example, in order to get real client IP REMOTE_ADDR may not be enough.
+
+.. code-block:: python
+
+    # views.py
+    def my_view(request):
+        remote_ip = request.META.get('REMOTE_ADDR')
+        form = MyForm(request.POST or None, remote_ip=remote_ip)
+
+    # forms.py
+    class MyForm(forms.Form):
+        turnstile = TurnstileField()
+    
+        def __init__(self, *args, remote_ip=None, **kwargs):
+            super().__init__(*args, **kwargs)
+            if remote_ip:
+                self.fields['turnstile'].remote_ip = remote_ip

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-turnstile
-version = 0.1.2
+version = 0.1.3
 description = Add Cloudflare Turnstile validator widget to the forms of your django project
 long_description = file: README.rst
 url = https://github.com/zmh-program

--- a/turnstile/fields.py
+++ b/turnstile/fields.py
@@ -19,7 +19,8 @@ class TurnstileField(forms.Field):
         'required': _('Please prove you are a human.'),
     }
 
-    def __init__(self, **kwargs):
+    def __init__(self, remote_ip = None, **kwargs):
+        self.remote_ip = remote_ip
         superclass_parameters = inspect.signature(super().__init__).parameters
         superclass_kwargs = {}
         widget_settings = DEFAULT_CONFIG.copy()
@@ -53,6 +54,7 @@ class TurnstileField(forms.Field):
         post_data = urlencode({
             'secret': SECRET,
             'response': value,
+            'remoteip': self.remote_ip,
         }).encode()
         request = Request(VERIFY_URL, post_data)
         try:


### PR DESCRIPTION
Looking at Turnstile documentation there is an additional field **remoteip** which can be sent for server-side validation
https://developers.cloudflare.com/turnstile/get-started/server-side-validation/#required-parameters

I've used 0.1.3 as version, I'm not sure at versioning scheme.
Django/Python supported versions may be require an update as well, I'm using it on django 5.2 with Python 3.13 by the way