### PR TITLE
fix: prevent DIV nesting in P tag for form.as_p()

### DIFF
--- a/turnstile/widgets.py
+++ b/turnstile/widgets.py
@@ -1,9 +1,11 @@
 from urllib.parse import urlencode
 from django import forms
+from django.forms import RenderableMixin
 from turnstile.settings import JS_API_URL, SITEKEY, ENABLE
 
 
-class TurnstileWidget(forms.Widget):
+class TurnstileWidget(RenderableMixin, forms.Widget):
+    input_type = "hidden"
     template_name = 'turnstile/forms/widgets/turnstile_widget.html'
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Issue #4: Using form.as_p() in templates results in invalid HTML.

Turnstile widget was rendered as DIV inside P tag.

Solution: Add RenderableMixin and set input_type=hidden to prevent Django from wrapping the widget in a P tag.

Happy to make any changes if needed!