### PR TITLE
feat: add turnstile verification service and DRF mixin

### DIFF
--- a/turnstile/fields.py
+++ b/turnstile/fields.py
@@ -1,13 +1,10 @@
 import inspect
-import json
-from urllib.error import HTTPError
-from urllib.parse import urlencode
-from urllib.request import build_opener, Request, ProxyHandler
 
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
-from turnstile.settings import DEFAULT_CONFIG, ENABLE, PROXIES, SECRET, TIMEOUT, VERIFY_URL
+from turnstile.services import TurnstileService, TurnstileVerificationException
+from turnstile.settings import DEFAULT_CONFIG, ENABLE
 from turnstile.widgets import TurnstileWidget
 
 
@@ -50,19 +47,17 @@ class TurnstileField(forms.Field):
         if not ENABLE:
             return
         super().validate(value)
-        opener = build_opener(ProxyHandler(PROXIES))
-        post_data = urlencode({
-            'secret': SECRET,
-            'response': value,
-            'remoteip': self.remote_ip,
-        }).encode()
-        request = Request(VERIFY_URL, post_data)
+
+        service = TurnstileService()
+
         try:
-            response = opener.open(request, timeout=TIMEOUT)
-        except HTTPError:
-            raise forms.ValidationError(self.error_messages['error_turnstile'], code='error_turnstile')
+            result = service.verify(
+                value,
+                self.remote_ip
+            )
 
-        response_data = json.loads(response.read().decode("utf-8"))
+        except TurnstileVerificationException:
+            raise forms.ValidationError(self.error_messages['error_turnstile'],code='error_turnstile')
 
-        if not response_data.get('success'):
+        if not result.success:
             raise forms.ValidationError(self.error_messages['invalid_turnstile'], code='invalid_turnstile')

--- a/turnstile/mixins/__init__.py
+++ b/turnstile/mixins/__init__.py
@@ -1,0 +1,3 @@
+from turnstile.mixins.base import TurnstileValidationMixin
+
+__all__ = ["TurnstileValidationMixin"]

--- a/turnstile/mixins/base.py
+++ b/turnstile/mixins/base.py
@@ -52,7 +52,6 @@ class TurnstileValidationMixin:
                 request.META.get('REMOTE_ADDR')
             )
         except TurnstileVerificationException as e:
-            print(str(e)) #TODO delete 
             raise APIException(_('Validation error.')) from e
 
         if not result.success:

--- a/turnstile/mixins/base.py
+++ b/turnstile/mixins/base.py
@@ -1,0 +1,59 @@
+from django.utils.translation import gettext_lazy as _
+from django.core.exceptions import ImproperlyConfigured
+
+from turnstile.services import TurnstileService, TurnstileVerificationException
+
+try:
+    from rest_framework.exceptions import ValidationError, APIException
+except ImportError as exc:
+    raise ImproperlyConfigured('Turnstile DRF mixin requires Django REST Framework.') from exc
+
+
+class TurnstileValidationMixin:
+
+    captcha_field_name = 'cf-turnstile-response'
+    methods = ["POST"]
+
+    def initial(self, request, *args, **kwargs):
+        """
+        Overrides the initial method to include Turnstile validation for 
+        specified HTTP methods.
+        """
+        super().initial(request, *args, **kwargs)
+
+        if request.method not in self.methods:
+            return
+
+        self.validate_turnstile(request)
+
+    def get_captcha_token(self, request):
+        """
+        Retrieves the captcha token from the request data.
+        """
+        return request.data.get(self.captcha_field_name)
+
+    def validate_turnstile(self, request):
+        """
+        Validates the Turnstile token from the request.
+        """
+        token = self.get_captcha_token(request)
+
+        if not token:
+            raise ValidationError({self.captcha_field_name: _('Captcha is required.')})
+
+        if not isinstance(token, str) or len(token) > 2048:
+            raise ValidationError({self.captcha_field_name: _('Invalid captcha format.')})
+
+        service = TurnstileService()
+
+        try:
+            result = service.verify(
+                token,
+                request.META.get('REMOTE_ADDR')
+            )
+        except TurnstileVerificationException as e:
+            print(str(e)) #TODO delete 
+            raise APIException(_('Validation error.')) from e
+
+        if not result.success:
+            raise ValidationError({self.captcha_field_name: _('Invalid captcha, captcha has expired or has already been used. Please try again.')})

--- a/turnstile/services.py
+++ b/turnstile/services.py
@@ -1,0 +1,69 @@
+import json
+import socket
+from urllib.parse import urlencode
+from urllib.request import Request, build_opener, ProxyHandler
+from urllib.error import URLError, HTTPError
+from django.utils.translation import gettext_lazy as _
+from dataclasses import dataclass
+from typing import List, Optional
+
+from turnstile.settings import SECRET, TIMEOUT, PROXIES, VERIFY_URL, EXPECTED_HOSTNAMES
+
+@dataclass
+class TurnstileVerificationResult:
+    """        
+    A dataclass representing the result of a Turnstile verification.
+    - success: A boolean indicating whether the verification was successful.
+    - error_codes: A list of error codes returned by the Turnstile API, if any.
+    - hostname: The hostname of the site where the verification was performed, if available.
+    """
+    success: bool
+    error_codes: List[str]
+    hostname: Optional[str]
+
+class TurnstileVerificationException(Exception):
+    """
+    Custom exception for Turnstile verification errors.
+    """
+    pass
+
+class TurnstileService:
+    def verify(self, token, remote_ip=None):
+        """
+        Verifies a Turnstile token.
+        """
+        data = {
+            'secret': SECRET,
+            'response': token,
+        }
+
+        if remote_ip:
+            data['remoteip'] = remote_ip
+
+        encoded_data = urlencode(data).encode()
+        request = Request(VERIFY_URL, encoded_data)
+        opener = build_opener(ProxyHandler(PROXIES))
+
+        try:
+            response = opener.open(request, timeout=TIMEOUT)
+            body = json.loads(response.read().decode())
+
+        except (HTTPError, URLError, socket.timeout) as e:
+            error_codes = []
+            if isinstance(e, HTTPError):
+                try:
+                    body = json.loads(e.read().decode())
+                    error_codes = body.get('error-codes', [])
+                except Exception:
+                    pass
+            
+            raise TurnstileVerificationException('Turnstile exception %s | codes: %s' % (str(e), str(error_codes)))
+
+        success = body.get('success', False)
+        error_codes = body.get('error-codes', [])
+        hostname = body.get('hostname', None)
+
+        if success and EXPECTED_HOSTNAMES and hostname not in EXPECTED_HOSTNAMES:
+            raise TurnstileVerificationException('Invalid hostname: %s' % hostname)
+
+        return TurnstileVerificationResult(success=success, error_codes=error_codes, hostname=hostname)

--- a/turnstile/settings.py
+++ b/turnstile/settings.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+EXPECTED_HOSTNAMES = getattr(settings, 'TURNSTILE_EXPECTED_HOSTNAMES', ['dev.washpass.app'])
 JS_API_URL = getattr(settings, 'TURNSTILE_JS_API_URL', 'https://challenges.cloudflare.com/turnstile/v0/api.js')
 VERIFY_URL = getattr(settings, 'TURNSTILE_VERIFY_URL', 'https://challenges.cloudflare.com/turnstile/v0/siteverify')
 SITEKEY = getattr(settings, 'TURNSTILE_SITEKEY', '1x00000000000000000000AA')

--- a/turnstile/settings.py
+++ b/turnstile/settings.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-EXPECTED_HOSTNAMES = getattr(settings, 'TURNSTILE_EXPECTED_HOSTNAMES', ['dev.washpass.app'])
+EXPECTED_HOSTNAMES = getattr(settings, 'TURNSTILE_EXPECTED_HOSTNAMES', [])
 JS_API_URL = getattr(settings, 'TURNSTILE_JS_API_URL', 'https://challenges.cloudflare.com/turnstile/v0/api.js')
 VERIFY_URL = getattr(settings, 'TURNSTILE_VERIFY_URL', 'https://challenges.cloudflare.com/turnstile/v0/siteverify')
 SITEKEY = getattr(settings, 'TURNSTILE_SITEKEY', '1x00000000000000000000AA')


### PR DESCRIPTION
Introduce a reusable Turnstile verification service that can be used by both Django forms and API endpoints.

- Add TurnstileValidationMixin for DRF views
- Add verification service
- Refactor fields to use the service